### PR TITLE
fix: browser-like headers and improved token handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ shutterfly_photos/
 token.txt
 foldernames.txt
 ignore_albums.txt
-rename_folders.py
+rename_folders.py__pycache__/

--- a/downloader.py
+++ b/downloader.py
@@ -28,14 +28,14 @@ class ShutterflyDownloader:
         self.session = requests.Session()
         self._is_cookie_auth = access_token.startswith('_thislife_session=')
         
-        # Handle session cookie auth — store cookie on the session
+        # Handle session cookie auth — store raw cookie header on the session
         if self._is_cookie_auth:
             session_value = access_token.split('_thislife_session=')[1].split(';')[0]
             session_value = urllib.parse.unquote(session_value)
-            self.session.cookies.set('_thislife_session', session_value,
-                                     domain='cmd.thislife.com')
+            self._cookie_header = f'_thislife_session={session_value}'
             print("Using session cookie authentication")
         else:
+            self._cookie_header = None
             print("Using access token authentication")
         
         # Parse token to extract claims and expiration
@@ -134,6 +134,12 @@ class ShutterflyDownloader:
                     'Sec-Fetch-Mode': 'cors',
                     'Sec-Fetch-Site': 'cross-site',
                 })
+
+                # For cookie auth, send the session cookie as a raw header
+                # (requests' cookie jar domain matching is unreliable across
+                # different thislife.com subdomains)
+                if self._cookie_header:
+                    req_headers['Cookie'] = self._cookie_header
 
                 # Shutterfly expects JSON payloads sent as a form-encoded
                 # string body (Content-Type stays x-www-form-urlencoded but

--- a/downloader.py
+++ b/downloader.py
@@ -17,8 +17,9 @@ class TokenExpiredError(Exception):
     pass
 
 class ShutterflyDownloader:
-    def __init__(self, access_token, output_dir="downloads", rate_limit_delay=0.1, max_retries=3, ignore_albums=None, max_parallel_workers=1):
+    def __init__(self, access_token, output_dir="downloads", rate_limit_delay=0.1, max_retries=3, ignore_albums=None, max_parallel_workers=1, verbose=False):
         self.access_token = access_token
+        self.verbose = verbose
         self.output_dir = Path(output_dir)
         self.rate_limit_delay = rate_limit_delay
         self.max_retries = max_retries
@@ -39,6 +40,14 @@ class ShutterflyDownloader:
         
         # Parse token to extract claims and expiration
         self.claims, self.token_expiry = self._parse_token(self.access_token)
+        self._debug(f"Token type: {'cookie' if self._is_cookie_auth else 'JWT' if '.' in self.access_token else 'other'}")
+        self._debug(f"Token expiry: {self.token_expiry}")
+        self._debug(f"Claims keys: {list(self.claims.keys())}")
+
+    def _debug(self, msg):
+        """Print a debug message when verbose mode is enabled."""
+        if self.verbose:
+            print(f"[DEBUG] {msg}")
         
         self.output_dir.mkdir(parents=True, exist_ok=True)
         
@@ -134,7 +143,16 @@ class ShutterflyDownloader:
                 if 'json' in kwargs:
                     kwargs['data'] = json.dumps(kwargs.pop('json'))
 
+                self._debug(f"Request: {method.upper()} {url}")
+                if 'data' in kwargs:
+                    self._debug(f"Payload: {kwargs['data'][:500]}")
+
                 response = getattr(self.session, method)(url, headers=req_headers, **kwargs)
+
+                self._debug(f"Response: {response.status_code}")
+                if not response.ok:
+                    self._debug(f"Response body: {response.text[:500]}")
+
                 response.raise_for_status()
                 
                 return response
@@ -189,11 +207,13 @@ class ShutterflyDownloader:
         # Environment variable always wins
         uid = os.environ.get('LIFE_UID')
         if uid:
+            self._debug(f"User ID from LIFE_UID env: {uid}")
             return uid
         
         # Try extracting from token claims
         uid = self.claims.get('sfly_uid')
         if uid:
+            self._debug(f"User ID from token claims (sfly_uid): {uid}")
             return uid
         
         # For cookie auth we must have a UID — prompt as last resort
@@ -235,7 +255,9 @@ class ShutterflyDownloader:
         response = self.make_request('post', url, json=payload)
         data = response.json()
         
+        self._debug(f"getAlbums response: success={data['result']['success']}")
         if not data['result']['success']:
+            self._debug(f"getAlbums error: {data['result']}")
             raise Exception(f"Failed to get albums: {data['result'].get('message', 'Unknown error')}")
         
         albums = []
@@ -960,6 +982,8 @@ def main():
                        help='Find and remove exact duplicate photos (keeps files with different content)')
     parser.add_argument('--thorough', action='store_true',
                        help='When deduping, check all albums even if they have the correct number of files')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                       help='Enable debug logging (shows requests, responses, token info)')
     
     args = parser.parse_args()
     
@@ -973,7 +997,8 @@ def main():
         output_dir=args.output_dir,
         rate_limit_delay=args.rate_limit,
         ignore_albums=args.ignore_albums,
-        max_parallel_workers=args.parallel_workers
+        max_parallel_workers=args.parallel_workers,
+        verbose=args.verbose,
     )
     
     if args.dedupe:

--- a/downloader.py
+++ b/downloader.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import json
 import base64
 from datetime import datetime, timedelta
+import urllib.parse
 import random
 import argparse
 from PIL import Image
@@ -24,46 +25,20 @@ class ShutterflyDownloader:
         self.ignore_albums = set(ignore_albums or [])  # Convert to set for faster lookups
         self.max_parallel_workers=max_parallel_workers
         self.session = requests.Session()
+        self._is_cookie_auth = access_token.startswith('_thislife_session=')
         
-        # Handle both access tokens and session cookies
-        if access_token.startswith('_thislife_session='):
-            # This is a session cookie, extract the session value
+        # Handle session cookie auth — store cookie on the session
+        if self._is_cookie_auth:
             session_value = access_token.split('_thislife_session=')[1].split(';')[0]
-            # URL decode the session value
-            import urllib.parse
             session_value = urllib.parse.unquote(session_value)
-            self.session.headers.update({
-                'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
-                'origin': 'https://photos.shutterfly.com',
-                'referer': 'https://photos.shutterfly.com/',
-                'cookie': f'_thislife_session={session_value}'
-            })
+            self.session.cookies.set('_thislife_session', session_value,
+                                     domain='cmd.thislife.com')
             print("Using session cookie authentication")
         else:
-            # This is an access token
-            self.session.headers.update({
-                'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
-                'origin': 'https://photos.shutterfly.com',
-                'referer': 'https://photos.shutterfly.com/'
-            })
             print("Using access token authentication")
         
-        # Parse token expiration if it's a JWT token, otherwise set default expiration
-        try:
-            token_parts = self.access_token.split('.')
-            if len(token_parts) == 3:  # JWT tokens have 3 parts
-                self.claims = json.loads(base64.b64decode(token_parts[1] + '=' * (-len(token_parts[1]) % 4)))
-                self.token_expiry = datetime.fromtimestamp(self.claims['exp'])
-            else:
-                # Not a JWT token, set default expiration to 1 hour from now
-                self.claims = {}
-                self.token_expiry = datetime.now() + timedelta(hours=1)
-                print("Warning: Token doesn't appear to be in JWT format. Setting default expiration to 1 hour.")
-        except Exception as e:
-            # If token parsing fails, set default expiration
-            self.claims = {}
-            self.token_expiry = datetime.now() + timedelta(hours=1)
-            print(f"Warning: Could not parse token expiration: {e}. Setting default expiration to 1 hour.")
+        # Parse token to extract claims and expiration
+        self.claims, self.token_expiry = self._parse_token(self.access_token)
         
         self.output_dir.mkdir(parents=True, exist_ok=True)
         
@@ -73,6 +48,44 @@ class ShutterflyDownloader:
             with open(ignore_file) as f:
                 self.ignore_albums.update(line.strip() for line in f if line.strip())
     
+    @staticmethod
+    def _parse_token(token):
+        """Parse a token string and return (claims_dict, expiry_datetime).
+        
+        Supports JWT tokens (three dot-separated parts) and URL-encoded
+        base64 blobs. Falls back to a 1-hour default expiry when the
+        format is unrecognised.
+        """
+        # Skip parsing for cookie-based auth
+        if token.startswith('_thislife_session='):
+            return {}, datetime.now() + timedelta(hours=1)
+        
+        # Try JWT first (header.payload.signature)
+        parts = token.split('.')
+        if len(parts) == 3:
+            try:
+                payload = parts[1] + '=' * (-len(parts[1]) % 4)
+                claims = json.loads(base64.b64decode(payload))
+                expiry = datetime.fromtimestamp(claims['exp'])
+                return claims, expiry
+            except Exception:
+                pass  # fall through to other formats
+        
+        # Try URL-decoded base64 blob
+        try:
+            decoded = urllib.parse.unquote(token)
+            raw = base64.b64decode(decoded + '=' * (-len(decoded) % 4))
+            claims = json.loads(raw.decode('utf-8'))
+            if 'exp' in claims:
+                return claims, datetime.fromtimestamp(claims['exp'])
+            return claims, datetime.now() + timedelta(hours=1)
+        except Exception:
+            pass
+        
+        # Unknown format — still usable, just can't extract claims
+        print("Warning: Could not parse token format. Setting default expiration to 1 hour.")
+        return {}, datetime.now() + timedelta(hours=1)
+
     def check_token_validity(self):
         """Check if token is still valid"""
         if datetime.now() >= self.token_expiry:
@@ -81,21 +94,7 @@ class ShutterflyDownloader:
     def update_access_token(self, new_token):
         """Update the access token and its expiration time"""
         self.access_token = new_token
-        try:
-            token_parts = self.access_token.split('.')
-            if len(token_parts) == 3:  # JWT tokens have 3 parts
-                self.claims = json.loads(base64.b64decode(token_parts[1] + '=' * (-len(token_parts[1]) % 4)))
-                self.token_expiry = datetime.fromtimestamp(self.claims['exp'])
-            else:
-                # Not a JWT token, set default expiration to 1 hour from now
-                self.claims = {}
-                self.token_expiry = datetime.now() + timedelta(hours=1)
-                print("Warning: New token doesn't appear to be in JWT format. Setting default expiration to 1 hour.")
-        except Exception as e:
-            # If token parsing fails, set default expiration
-            self.claims = {}
-            self.token_expiry = datetime.now() + timedelta(hours=1)
-            print(f"Warning: Could not parse new token expiration: {e}. Setting default expiration to 1 hour.")
+        self.claims, self.token_expiry = self._parse_token(new_token)
         print("Access token updated successfully")
 
     def make_request(self, method, url, **kwargs):
@@ -111,7 +110,31 @@ class ShutterflyDownloader:
                     print(f"Retrying in {wait_time:.1f} seconds...")
                     time.sleep(wait_time)
                 
-                response = getattr(self.session, method)(url, **kwargs)
+                # Browser-like headers to avoid request validation rejection
+                req_headers = kwargs.pop('headers', {})
+                req_headers.update({
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+                    'Origin': 'https://photos.shutterfly.com',
+                    'Referer': 'https://photos.shutterfly.com/',
+                    'User-Agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+                                   'AppleWebKit/605.1.15 (KHTML, like Gecko) '
+                                   'Version/18.5 Safari/605.1.15'),
+                    'Accept': 'application/json, text/javascript, */*; q=0.01',
+                    'Accept-Language': 'en-US,en;q=0.9',
+                    'Sec-Fetch-Dest': 'empty',
+                    'Sec-Fetch-Mode': 'cors',
+                    'Sec-Fetch-Site': 'cross-site',
+                })
+
+                # Shutterfly expects JSON payloads sent as a form-encoded
+                # string body (Content-Type stays x-www-form-urlencoded but
+                # the value is a raw JSON string).  The `requests` library's
+                # `json=` kwarg sets Content-Type to application/json which
+                # gets rejected, so we serialise manually.
+                if 'json' in kwargs:
+                    kwargs['data'] = json.dumps(kwargs.pop('json'))
+
+                response = getattr(self.session, method)(url, headers=req_headers, **kwargs)
                 response.raise_for_status()
                 
                 return response
@@ -161,113 +184,56 @@ class ShutterflyDownloader:
                 print(f"Unexpected error: {str(e)}")
                 raise
 
+    def _resolve_user_id(self):
+        """Resolve the Shutterfly user ID from env, token claims, or user prompt."""
+        # Environment variable always wins
+        uid = os.environ.get('LIFE_UID')
+        if uid:
+            return uid
+        
+        # Try extracting from token claims
+        uid = self.claims.get('sfly_uid')
+        if uid:
+            return uid
+        
+        # For cookie auth we must have a UID — prompt as last resort
+        if self._is_cookie_auth:
+            print("\nNo LIFE_UID found in environment variables.")
+            print("This is required when using a _thislife_session cookie.")
+            print("You can find your UID in the getAlbums response payload in")
+            print("your browser's Network tab, or set it as an environment variable:")
+            print("  export LIFE_UID=your_uid_here")
+            uid = input("Please enter your Shutterfly user ID: ").strip()
+            if not uid:
+                raise Exception("User ID is required to proceed when using session cookie auth")
+            return uid
+        
+        return None
+
     def get_albums(self):
         """Fetch all albums from Shutterfly"""
         url = 'https://cmd.thislife.com/json?method=album.getAlbums'
+        user_id = self._resolve_user_id()
         
-        # Determine user ID source depending on auth method
-        # - For session cookie auth, LIFE_UID is required (prompt if missing)
-        # - For access token auth, prefer token claims (sfly_uid) then LIFE_UID if present
-        user_id = None
-        if self.access_token.startswith('_thislife_session='):
-            user_id = os.environ.get('LIFE_UID')
-            if not user_id:
-                print("\nNo LIFE_UID found in environment variables.")
-                print("This is required when using a _thislife_session cookie.")
-                print("You can find your UID in the URL of your Shutterfly account page")
-                print("or set it as an environment variable: export LIFE_UID=your_uid_here")
-                user_id = input("Please enter your Shutterfly user ID: ").strip()
-                if not user_id:
-                    raise Exception("User ID is required to proceed when using session cookie auth")
+        # For cookie auth the session cookie is sent via the Cookie header
+        # (handled by self.session) and the UID goes as the first param.
+        # For token auth the access token is first, UID second.
+        if self._is_cookie_auth:
+            params = [user_id, None, None, True]
         else:
-            # Access token path: try claims first, then environment (do not prompt)
-            user_id = (self.claims or {}).get('sfly_uid') or os.environ.get('LIFE_UID')
+            params = [self.access_token, user_id, None, None, True]
         
-        # Handle different authentication methods
-        if self.access_token.startswith('_thislife_session='):
-            # Using session cookie - try both with and without access token
-            # First try with just the session cookie
-            payload = {
-                "method": "album.getAlbums",
-                "params": [
-                    user_id,  # User ID as first param
-                    None,
-                    None,
-                    True
-                ],
-                "headers": {
-                    "X-SFLY-SubSource": "library"
-                },
-                "id": None
-            }
-            
-            print(f"Debug: Trying with session cookie only...")
-            response = self.make_request('post', url, json=payload)
-            data = response.json()
-            
-            if data['result']['success']:
-                print("Success with session cookie only!")
-            else:
-                print(f"Session cookie only failed: {data['result'].get('message', 'Unknown error')}")
-                # Try with a placeholder token in case the API expects one
-                payload["params"] = [
-                    "placeholder_token",  # Try with a placeholder
-                    user_id,
-                    None,
-                    None,
-                    True
-                ]
-                print(f"Debug: Trying with placeholder token...")
-                response = self.make_request('post', url, json=payload)
-                data = response.json()
-        else:
-            # Using access token - send token in params
-            # Try different parameter orders since API is saying "Wrong or missing Parameter"
-            payload = {
-                "method": "album.getAlbums",
-                "params": [
-                    self.access_token,
-                    user_id,  # Use the user ID we just got
-                    None,
-                    None,
-                    True
-                ],
-                "headers": {
-                    "X-SFLY-SubSource": "library"
-                },
-                "id": None
-            }
-            
-            print(f"Debug: Trying with token first, user ID second...")
-            response = self.make_request('post', url, json=payload)
-            data = response.json()
-            
-            if data['result']['success']:
-                print("Success with token first!")
-            else:
-                print(f"Token first failed: {data['result'].get('message', 'Unknown error')}")
-                # Try with user ID first, token second
-                payload["params"] = [
-                    user_id,
-                    self.access_token,
-                    None,
-                    None,
-                    True
-                ]
-                print(f"Debug: Trying with user ID first, token second...")
-                response = self.make_request('post', url, json=payload)
-                data = response.json()
-        
-        print(f"Debug: Making request to {url}")
-        print(f"Debug: Payload: {json.dumps(payload, indent=2)}")
-        print(f"Debug: Access token: {self.access_token[:20]}...")
-        print(f"Debug: User ID: {user_id}")
+        payload = {
+            "method": "album.getAlbums",
+            "params": params,
+            "headers": {
+                "X-SFLY-SubSource": "library"
+            },
+            "id": None
+        }
         
         response = self.make_request('post', url, json=payload)
         data = response.json()
-        
-        print(f"Debug: Response status: {response.status_code}")
-        print(f"Debug: Response data: {json.dumps(data, indent=2)}")
         
         if not data['result']['success']:
             raise Exception(f"Failed to get albums: {data['result'].get('message', 'Unknown error')}")


### PR DESCRIPTION
## Problem

Shutterfly tightened their API request validation, causing 'Invalid token' and 'Wrong or missing Parameter' errors for users who previously had working setups. Reported in #10, confirmed by multiple users.

## Root Cause

The script was sending requests with minimal headers and using `requests`'s `json=` parameter (which sets `Content-Type: application/json`). Shutterfly's API actually expects:
1. Browser-like headers (User-Agent, Sec-Fetch-*, Origin, Referer)
2. JSON payloads sent as raw string data with `Content-Type: x-www-form-urlencoded` — this is how the browser sends it

## Changes

- **Browser-like headers** in all API requests (User-Agent, Sec-Fetch-*, Accept, etc.)
- **Form-encoded JSON payloads** — serialise JSON manually as string `data=` instead of using `json=` kwarg
- **Cleaner token parsing** — extracted into `_parse_token()` static method, supports JWT and non-JWT formats gracefully
- **Removed debug noise** — no more `Debug: Trying with token first...` print statements
- **Removed dual-try auth logic** — the old code tried token-first then uid-first; with proper headers, the standard order works
- **Preserved cookie auth** — session cookie path still works correctly
- **Added `__pycache__/` to .gitignore**

## Testing

All 12 existing tests pass. Credit to @rsdickerson's fork for identifying the core issue.

Fixes #10